### PR TITLE
rc4 dcrinstall links

### DIFF
--- a/src/config.toml
+++ b/src/config.toml
@@ -10,8 +10,8 @@ baseurl = "https://dex.decred.org/"
   # Client download URLs
 
   # Windows
-  win_url = "https://github.com/decred/decred-release/releases/download/v1.6.0-rc3/dcrinstall-windows-amd64-v1.6.0-rc3.exe"
+  win_url = "https://github.com/decred/decred-release/releases/download/v1.6.0-rc4/dcrinstall-windows-amd64-v1.6.0-rc4.exe"
   # macOS
-  mac_url = "https://github.com/decred/decred-release/releases/download/v1.6.0-rc3/dcrinstall-darwin-amd64-v1.6.0-rc3"
+  mac_url = "https://github.com/decred/decred-release/releases/download/v1.6.0-rc4/dcrinstall-darwin-amd64-v1.6.0-rc4"
   # Linux
-  lin_url = "https://github.com/decred/decred-release/releases/download/v1.6.0-rc3/dcrinstall-linux-amd64-v1.6.0-rc3"
+  lin_url = "https://github.com/decred/decred-release/releases/download/v1.6.0-rc4/dcrinstall-linux-amd64-v1.6.0-rc4"


### PR DESCRIPTION
This updates the dcrinstall links for rc4.

We might also considering adding the 32 bit and arm links now that the installers support those too even for dexc. https://github.com/decred/decred-binaries/releases/tag/v1.6.0-rc4 includes dexc for darwin-amd64, freebsd-amd64, linux-{386,amd64,arm,arm64}, windows-{386,amd64}, and openbsd-amd64.

Resolves https://github.com/decred/dcrdex/issues/866