### PR TITLE
update for 0.1 fee

### DIFF
--- a/src/layouts/partials/get-started.html
+++ b/src/layouts/partials/get-started.html
@@ -42,7 +42,9 @@
                             Run dcrd to sync the Decred chain, dcrwallet to manage
                             your decred, bitcoind to manage your bitcoin, and dexc
                             to connect to the DCRDEX server.  Make a deposit to your
-                            Decred wallet of at least 1.0001 DCR.
+                            Decred wallet of at least 0.1001 DCR to cover the current
+                            registration fee plus network transaction fees. Additional
+                            assets will be supported for registration in the future.
                         </div>
                     
                         <input type="radio" name="get-started-accordion" id="get-started-accordion-3">
@@ -57,7 +59,7 @@
                         <div class="accordion-body">
                             Once your chains are synced and wallets are registered
                             with dexc, the DCRDEX client, you must pay a one-time
-                            fee of 1 DCR to the server and wait for the payment to
+                            fee of 0.1 DCR to the server and wait for the payment to
                             confirm. This is done to make bad client behavior
                             expensive.
                         </div>
@@ -73,6 +75,7 @@
                         </label>
                         <div class="accordion-body">
                             To place an order, fill out the price, the lot quantity, and submit it.
+                            Stay online and keep everything running until the trade settles.
                         </div>
     
                         <div style="flex: 1;"></div>


### PR DESCRIPTION
This updates the getting started instructions for the new 0.1 DCR fee.

This also adds a note about plans to support different assets for registration fees,
and a note about keeping things running after placing an order.

I have kept these changes terse, but I believe they are important to have on the landing.