### PR TITLE
Link to Decrediton rather than dcrinstall

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist/
 src/resources/_gen
 src/public
+.hugo_build.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # builder image
 FROM alpine:latest
 
-ENV HUGO_VERSION 0.88.1
+ENV HUGO_VERSION 0.94.2
 
 LABEL description="gohugo build"
 LABEL version="1.0"

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 ISC License
 
-Copyright (c) 2020-2021 The Decred developers
+Copyright (c) 2020-2022 The Decred developers
 
 Permission to use, copy, modify, and distribute this software for any
 purpose with or without fee is hereby granted, provided that the above

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -19,5 +19,14 @@ server {
         index  index.html index.htm;
     }
 
+    gzip on;
+    gzip_disable "msie6";
+
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_comp_level 6;
+    gzip_buffers 16 8k;
+    gzip_http_version 1.1;
+    gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
 }
 

--- a/src/assets/scss/accordion.scss
+++ b/src/assets/scss/accordion.scss
@@ -88,7 +88,7 @@
     overflow: hidden;
     position: relative;
     padding: 0 1.5em;
-    color: $p-text-color;
+    color: $p-dark-gray;
     flex: 1;
     transition: all 0.4s ease-out;
     -webkit-transition: all 0.4s ease-out;

--- a/src/assets/scss/colors.scss
+++ b/src/assets/scss/colors.scss
@@ -1,5 +1,6 @@
 $bg-color: #eee;
-$p-text-color: #3F486A;
+$p-dark-gray: #3F486A;
+$p-light-gray: #5a6d81;
 $highlight-blue: #2970FF;
 
 // Official Decred colors

--- a/src/assets/scss/downloads.scss
+++ b/src/assets/scss/downloads.scss
@@ -1,51 +1,95 @@
 .download-section {
 
+    background-color: white;
+    color: $dark-blue;
+    text-align: center;
+
     h1 {
         text-align: center;
         padding-top: 80px;
-        font-size: 24px;
+        font-size: 28px;
         color: $dark-blue;
         padding-bottom: 24px;
     }
 
     .downloads-container {
-        a {
-            font-size: 16px;
-            color: $dark-blue;
-            padding: 4px 22px;
-            margin: 10px 20px;
-    
-            img {
-                padding-right: 16px;
-                height: 22px;
-            }
-        }
-
-        max-width: 660px;
         display: flex;
-        margin: 0 auto;
         flex-direction: row;
-        align-items: center;
-        justify-content: space-between;
-    }
-    
-    .download {
-        display: flex;
+        flex-wrap: wrap;
         align-items: center;
         justify-content: center;
 
-        a {
+        .download {
+               
             display: flex;
-            flex-wrap: 0;
-            flex-direction: row;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            background-color: #f1f1f1;
+            border: 2px solid #f1f1f1;
+            border-radius: 8px;
+            font-size: 16px;
+            padding: 0;
+            margin: 24px;
+
+            .btn-bg {
+                background: white;
+                border-radius: 0 0 8px 8px;
+                font-size: 14px;
+                padding-bottom: 12px;
+                color: $p-light-gray;
+            }
+    
+            a {
+                color: $p-light-gray;
+                text-decoration: none;
+            }
+            a:hover {
+                text-decoration: underline;
+            }
+            a.btn {
+                text-decoration: none;
+                margin: 30px 60px 18px;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                flex-direction: row;
+                font-size: 16px;
+                color: white;
+            }
+
+            img {
+                height: 40px;
+                width: 40px;
+                margin: 14px 14px 14px 0;
+            }
         }
+
+    }
+
+    .cli {
+        padding: 12px;
+        font-size: 16px;
+        
+        a,
+        a:visited,
+        a:hover,
+        a:active {
+            font-weight: bold;
+            color: $p-light-gray;
+            text-decoration: none;
+        }
+        a:hover {
+            text-decoration: underline;
+        }
+
     }
 
     .verify {
         max-width: 450px;
         margin: 22px auto;
         font-style: italic;
-        color: $p-text-color;
+        color: $p-dark-gray;
         text-align: center;
     }
 }

--- a/src/config.toml
+++ b/src/config.toml
@@ -7,15 +7,10 @@ baseurl = "https://dex.decred.org/"
   images = ["/og-card.png"]
   description = "DCRDEX is an open source, peer-to-peer cryptocurrency exchange built by the Decred Project."
 
-  # Client download URLs
-
-  # Windows
-  win_url = "https://github.com/decred/decred-release/releases/download/v1.7.1/dcrinstall-windows-amd64-v1.7.1.exe"
-  # macOS
-  mac_url = "https://github.com/decred/decred-release/releases/download/v1.7.1/dcrinstall-darwin-amd64-v1.7.1.pkg"
-  # Linux
-  lin_url = "https://github.com/decred/decred-release/releases/download/v1.7.1/dcrinstall-linux-amd64-v1.7.1"
-  # Manifest
-  manifest_url = "https://github.com/decred/decred-release/releases/download/v1.7.1/dcrinstall-v1.7.1-manifest.txt"
-  # Manifest signature
-  manifest_sig_url = "https://github.com/decred/decred-release/releases/download/v1.7.1/dcrinstall-v1.7.1-manifest.txt.asc"
+  # Download URLs
+  win_decrediton_url = "https://github.com/decred/decred-binaries/releases/download/v1.7.1/decrediton-v1.7.1.exe"
+  mac_decrediton_url = "https://github.com/decred/decred-binaries/releases/download/v1.7.1/decrediton-amd64-v1.7.1.dmg"
+  m1_decrediton_url  = "https://github.com/decred/decred-binaries/releases/download/v1.7.1/decrediton-arm64-v1.7.1.dmg"
+  lin_decrediton_url = "https://github.com/decred/decred-binaries/releases/download/v1.7.1/decrediton-v1.7.1.AppImage"
+  tar_decrediton_url = "https://github.com/decred/decred-binaries/releases/download/v1.7.1/decrediton-v1.7.1.tar.gz"
+  dcrinstall_url     = "https://github.com/decred/decred-release/releases/tag/v1.7.1"

--- a/src/layouts/partials/downloads.html
+++ b/src/layouts/partials/downloads.html
@@ -1,38 +1,74 @@
 <section class="download-section" id="downloads">
     <div class="container">
 
-        <h1>Download DCRDEX client</h1>
+        <h1>DCRDEX is available in Decrediton</h1>
 
-        <div class="downloads-container row">
+        <div class="downloads-container">
 
-            <div class="download col-12 col-sm-3">
+            {{ $download_links := .Site.Data.wallets.links.release_page_1_6 }}
+
+            <div class="download">
                 {{ $winblue := resources.Get "/images/win-blue.svg" }}
-                <a href="{{ $.Site.Params.win_url }}" rel="noopener noreferrer">
-                    <img src="{{ $winblue.Permalink }}" />Windows&nbsp;x64&nbsp;&nbsp;↓
-                </a>
-            </div>
-        
-            <div class="download col-12 col-sm-3">
-                {{ $macblue := resources.Get "/images/mac-blue.svg" }}
-                <a href="{{ $.Site.Params.mac_url }}" rel="noopener noreferrer">
-                    <img src="{{ $macblue.Permalink }}" />macOS&nbsp;&nbsp;↓
-                </a>
-            </div>
-        
-            <div class="download col-12 col-sm-3">
-                {{ $linuxblue := resources.Get "/images/linux-blue.svg" }}
-                <a href="{{ $.Site.Params.lin_url }}" rel="noopener noreferrer">
-                    <img src="{{ $linuxblue.Permalink }}" />Linux&nbsp;x64&nbsp;&nbsp;↓
-                </a>
-            </div>
+                <div>
+                    <img src="{{ $winblue.Permalink }}"/>
+                    <span>Windows&nbsp;x64</span>
+                </div>
 
+                <div class="btn-bg">
+                    <a class="btn btn-primary" href="{{ $.Site.Params.win_decrediton_url }}" rel="noopener noreferrer">
+                        Download
+                    </a>
+                    <span>Sorry - no 32-bit</span>
+                </div>
+            </div>
+        
+            <div class="download">
+
+                {{ $macblue := resources.Get "/images/mac-blue.svg" }}
+                <div>
+                    <img src="{{ $macblue.Permalink }}"/>
+                    <span>macOS</span>
+                </div>
+
+                <div class="btn-bg">
+                    <a class="btn btn-primary" href="{{ $.Site.Params.mac_decrediton_url }}" rel="noopener noreferrer">
+                        Download
+                    </a>
+                    <a href="{{ $.Site.Params.m1_decrediton_url }}" rel="noopener noreferrer">
+                        Apple Silicon
+                    </a>
+                </div>
+            </div>
+        
+            <div class="download">
+
+                {{ $linuxblue := resources.Get "/images/linux-blue.svg" }}
+                <div>
+                    <img src="{{ $linuxblue.Permalink }}"/>
+                    <span>Linux&nbsp;x64</span>
+                </div>
+
+                <div class="btn-bg">
+                    <a class="btn btn-primary" href="{{ $.Site.Params.lin_decrediton_url }}" rel="noopener noreferrer">
+                        Download
+                    </a>
+                    <a href="{{ $.Site.Params.tar_decrediton_url }}" rel="noopener noreferrer">
+                        Prefer a tarball?
+                    </a>
+                </div>
+            </div>
+        
         </div>
 
-        <p class="verify">To verify that the files have not been modified, also download the
-            <a href="{{ $.Site.Params.manifest_url }}" rel="noopener noreferrer">manifest</a> and the
-            <a href="{{ $.Site.Params.manifest_sig_url }}" rel="noopener noreferrer">signature</a>, and follow
-            <a href="https://docs.decred.org/advanced/verifying-binaries/" rel="noopener noreferrer">these steps</a>.</p>
-
-    </div>
+        <div class="cli">
+            <a href="{{ $.Site.Params.dcrinstall_url }}" rel="noopener noreferrer">
+                Click here to download DCRDEX command line tools&nbsp;&nbsp;↓
+            </a>
+        </div>
+        
+        <p class="verify">
+            Follow <a href="https://docs.decred.org/advanced/verifying-binaries/" rel="noopener noreferrer">these steps</a>
+            to verify that the files you download are legitimate and have not been modified.
+        </p>
     
 </section>

--- a/src/layouts/partials/footer.html
+++ b/src/layouts/partials/footer.html
@@ -115,7 +115,7 @@
         <div class="container h-100">
             <div class="row h-100 d-flex align-items-center">
                 <div class="col-12 col-lg-6 bold">
-                    © 2020-2021 Decred Developers, All Rights Reserved.
+                    © 2020-2022 Decred Developers, All Rights Reserved.
                 </div>
                 <div class="col-12 col-lg-6 text-lg-right">
                     DCRDEX development is funded by

--- a/src/layouts/partials/footer.html
+++ b/src/layouts/partials/footer.html
@@ -29,24 +29,24 @@
                     </ul>
 
                     <p>
-                        Download DCRDEX client:
+                        Download Decrediton to access DCRDEX:
                     </p>
 
                     <ul>
                         <li style="padding-right: 19px;">
                             {{ $win := resources.Get "/images/win.svg" }}
                             <img height="14px" src="{{ $win.Permalink }}" />
-                            <a href="{{ $.Site.Params.win_url }}" rel="noopener noreferrer">Windows x64</a>
+                            <a href="{{ $.Site.Params.win_decrediton_url }}" rel="noopener noreferrer">Windows x64</a>
                         </li>
                         <li style="padding-right: 19px;">
                             {{ $mac := resources.Get "/images/mac.svg" }}
                             <img height="14px" src="{{ $mac.Permalink }}" />
-                            <a href="{{ $.Site.Params.mac_url }}" rel="noopener noreferrer">macOS</a>
+                            <a href="{{ $.Site.Params.mac_decrediton_url }}" rel="noopener noreferrer">macOS</a>
                         </li>
                         <li>
                             {{ $linux := resources.Get "/images/linux.svg" }}
                             <img height="14px" src="{{ $linux.Permalink }}" />
-                            <a href="{{ $.Site.Params.lin_url }}" rel="noopener noreferrer">Linux x64</a>
+                            <a href="{{ $.Site.Params.lin_decrediton_url }}" rel="noopener noreferrer">Linux x64</a>
                         </li>
                     </ul>
 


### PR DESCRIPTION
This updates the download links to point to decrediton, taking styling from https://decred.org/release.

Part of #20, but I wont close that issue yet because there are still some pieces of text which need to be updated as well.

# Download links

![Screenshot from 2022-03-14 11-03-59](https://user-images.githubusercontent.com/6762864/158159999-e0ccc1f8-58c5-4b86-a615-c01ce027c60b.png)

# Footer

![Screenshot from 2022-03-14 11-04-07](https://user-images.githubusercontent.com/6762864/158160004-532aeec6-a4cd-44af-9969-b649cf5f63d5.png)

