### PR TITLE
temporarily disable outdated decrediton links

### DIFF
--- a/src/assets/scss/downloads.scss
+++ b/src/assets/scss/downloads.scss
@@ -49,6 +49,12 @@
             a:hover {
                 text-decoration: underline;
             }
+            a.disabled {
+                pointer-events: none;
+                cursor: default;
+                text-decoration: none;
+                color: lightgray;
+            }
             a.btn {
                 text-decoration: none;
                 margin: 30px 60px 18px;

--- a/src/assets/scss/footer.scss
+++ b/src/assets/scss/footer.scss
@@ -14,6 +14,12 @@ footer {
     text-decoration: underline;
     color: white;
   }
+  a.disabled {
+    pointer-events: none;
+    cursor: default;
+    text-decoration: none;
+    color: lightgray;
+}
 
   .footer-icon {
     padding-right: 23px;

--- a/src/layouts/partials/downloads.html
+++ b/src/layouts/partials/downloads.html
@@ -2,6 +2,9 @@
     <div class="container">
 
         <h1>DCRDEX is available in Decrediton or as a standalone application</h1>
+        <h2>v0.5 is now released!</h2>
+        <h4>NOTE: Only the <a href="{{ $.Site.Params.dexreleases_url }}" rel="noopener noreferrer">standalone application</a> is available at this time.
+        Check back later for Decrediton downloads.</h4>
 
         <div class="downloads-container">
 
@@ -15,7 +18,7 @@
                 </div>
 
                 <div class="btn-bg">
-                    <a class="btn btn-primary" href="{{ $.Site.Params.win_decrediton_url }}" rel="noopener noreferrer">
+                    <a class="btn btn-primary disabled" href="{{ $.Site.Params.win_decrediton_url }}" rel="noopener noreferrer">
                         Download
                     </a>
                     <span>Sorry - no 32-bit</span>
@@ -31,10 +34,10 @@
                 </div>
 
                 <div class="btn-bg">
-                    <a class="btn btn-primary" href="{{ $.Site.Params.mac_decrediton_url }}" rel="noopener noreferrer">
+                    <a class="btn btn-primary disabled" href="{{ $.Site.Params.mac_decrediton_url }}" rel="noopener noreferrer">
                         Download
                     </a>
-                    <a href="{{ $.Site.Params.m1_decrediton_url }}" rel="noopener noreferrer">
+                    <a class="disabled" href="{{ $.Site.Params.m1_decrediton_url }}" rel="noopener noreferrer">
                         Apple Silicon
                     </a>
                 </div>
@@ -49,10 +52,10 @@
                 </div>
 
                 <div class="btn-bg">
-                    <a class="btn btn-primary" href="{{ $.Site.Params.lin_decrediton_url }}" rel="noopener noreferrer">
+                    <a class="btn btn-primary disabled" href="{{ $.Site.Params.lin_decrediton_url }}" rel="noopener noreferrer">
                         Download
                     </a>
-                    <a href="{{ $.Site.Params.tar_decrediton_url }}" rel="noopener noreferrer">
+                    <a class="disabled" href="{{ $.Site.Params.tar_decrediton_url }}" rel="noopener noreferrer">
                         Prefer a tarball?
                     </a>
                 </div>

--- a/src/layouts/partials/footer.html
+++ b/src/layouts/partials/footer.html
@@ -43,7 +43,10 @@
                         </div>
                     </div>
 
-                    <p>
+                     <p style="font-weight: bold;">
+                        Decrediton downloads are temporarily unavailable. Check back later, or use the standalone application (below) instead.
+                    </p>
+                    <!--<p>
                         Download Decrediton to access DCRDEX:
                     </p>
 
@@ -51,22 +54,22 @@
                         <li style="padding-right: 19px;">
                             {{ $win := resources.Get "/images/win.svg" }}
                             <img height="14px" src="{{ $win.Permalink }}" />
-                            <a href="{{ $.Site.Params.win_decrediton_url }}" rel="noopener noreferrer">Windows x64</a>
+                            <a class="disabled" href="{{ $.Site.Params.win_decrediton_url }}" rel="noopener noreferrer">Windows x64</a>
                         </li>
                         <li style="padding-right: 19px;">
                             {{ $mac := resources.Get "/images/mac.svg" }}
                             <img height="14px" src="{{ $mac.Permalink }}" />
-                            <a href="{{ $.Site.Params.mac_decrediton_url }}" rel="noopener noreferrer">macOS</a>
+                            <a class="disabled" href="{{ $.Site.Params.mac_decrediton_url }}" rel="noopener noreferrer">macOS</a>
                         </li>
                         <li>
                             {{ $linux := resources.Get "/images/linux.svg" }}
                             <img height="14px" src="{{ $linux.Permalink }}" />
-                            <a href="{{ $.Site.Params.lin_decrediton_url }}" rel="noopener noreferrer">Linux x64</a>
+                            <a class="disabled" href="{{ $.Site.Params.lin_decrediton_url }}" rel="noopener noreferrer">Linux x64</a>
                         </li>
-                    </ul>
+                    </ul>-->
 
                     <p>
-                        Or, download the
+                        Download the
                         <a href="{{ $.Site.Params.dexreleases_url }}" rel="noopener noreferrer">
                         standalone application</a>.
                     </p>


### PR DESCRIPTION
This temporarily disables the Decrediton download links as there is no build available yet with the updated DEX.

People are getting into trouble using the old version thinking it is the latest 0.5.x release, particularly when they upgrade litecoind and bitcoind.