### PR TITLE
Remove Umbrel link for Decrediton. 

### DIFF
--- a/src/assets/scss/downloads.scss
+++ b/src/assets/scss/downloads.scss
@@ -22,7 +22,7 @@
         display: flex;
         flex-direction: row;
         flex-wrap: wrap;
-        align-items: flex-start;
+        align-items: normal;
         justify-content: center;
 
         .download {
@@ -30,7 +30,6 @@
             display: flex;
             flex-direction: column;
             align-items: center;
-            justify-content: center;
             background-color: #f1f1f1;
             border: 2px solid #f1f1f1;
             border-radius: 8px;
@@ -39,6 +38,7 @@
             margin: 24px;
 
             .btn-bg {
+                flex-grow: 1;
                 background: white;
                 border-radius: 0 0 8px 8px;
                 font-size: 14px;

--- a/src/layouts/partials/downloads.html
+++ b/src/layouts/partials/downloads.html
@@ -164,24 +164,6 @@
                 </div>
             </div>
         
-            <div class="download">
-
-                {{ $umbrelblue := resources.Get "/images/umbrel-blue.svg" }}
-                <div>
-                    <img src="{{ $umbrelblue.Permalink }}"/>
-                    <span>Umbrel</span>
-                </div>
-
-                <div class="btn-bg">
-                    <a class="btn btn-primary" href="{{ $.Site.Params.umbrel_community_app_store_url }}" rel="noopener noreferrer">
-                        App Store
-                    </a>
-                    <a href="{{ $.Site.Params.umbrel_community_app_store_url }}" rel="noopener noreferrer">
-                        The Decred Community App Store
-                    </a>
-                </div>
-            </div>
-
         </div>
     </div>
 

--- a/src/layouts/partials/footer.html
+++ b/src/layouts/partials/footer.html
@@ -109,6 +109,7 @@
                         Download
                         <a href="{{ $.Site.Params.dexreleases_url }}" rel="noopener noreferrer">
                         Bison Wallet</a>
+                        <!-- Hide Umbrel until updated -->
                         <div class="d-none">
                             , <br/>
                             {{ $umbrel := resources.Get "/images/umbrel.svg" }}


### PR DESCRIPTION
The Umbrel store only provides a dcrdex/bisonw app, not decrediton.

The Umbrel link for Bison Wallet remains hidden until it has been appropriately updated, otherwise it will link to software which does not work.